### PR TITLE
Added MSRV value to crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v3
+      
     - name: Check Formatting
       run: cargo fmt --all --check
   
@@ -24,7 +26,20 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
-    - uses: actions/checkout@v3
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    - name: Determine MSRV
+      shell: bash
+      run: |
+        msrv=$(grep rust-version Cargo.toml | cut -d '"' -f2)
+        echo "MSRV=$msrv" >> $GITHUB_ENV
+
+    - name: Install MSRV rustc
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ env.MSRV }}
+
     - name: Build
       run: cargo build --verbose
     - name: Run tests

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,7 +40,7 @@ jobs:
 
     - name: Strip release binary (linux and macos)
       if: matrix.build == 'linux' || matrix.build == 'macos'
-      run: strip "target/release/rg"
+      run: strip "target/release/jolly"
 
     - name: Build archive
       shell: bash

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ repository = "https://github.com/apgoetz/jolly"
 readme = "README.md"
 keywords = ["launcher","bookmarks", "iced"]
 exclude = ["docs/"]
+rust-version = "1.65"
 
 [dependencies]
 iced = "0.6.0"

--- a/README.md
+++ b/README.md
@@ -17,6 +17,12 @@ Alternatively, for rust users, Jolly can be installed via cargo:
 cargo install jolly
 ```
 
+**Regarding Minimum Supported Rust Version**: Jolly
+uses [iced](https://github.com/iced-rs/iced) for its GUI implementation, which
+is a fast moving project that generally only targets the latest stable
+rustc. Therefore Jolly will also usually target the same MSRV as
+`iced`. (Currently 1.65.0)
+
 # Quick Introduction
 
 To use Jolly, simply run the `jolly` executable. Jolly will look for a
@@ -69,4 +75,3 @@ interface.
 Hence Jolly: the curation of notetaking apps, with the instantaneous
 gratification of an app launcher, and sharp edges exposed that your
 web browser doesn't want you to have.
-

--- a/RELEASE-CHECKLIST.md
+++ b/RELEASE-CHECKLIST.md
@@ -3,10 +3,14 @@ Release Checklist
 This checklist is based on ripgrep release process . 
 
 * Ensure local `master` is up to date with respect to `origin/master`.
+* Make sure that `rustc --version` matches MSRV. 
 * Run `cargo update` and review dependency updates. Commit updated
   `Cargo.lock`.
 * Run `cargo outdated -d 1` and review semver incompatible updates. Unless there is
-  a strong motivation otherwise, review and update every dependency. 
+  a strong motivation otherwise, review and update every dependency.
+* Run `cargo test` or `cargo msrv` to check if MSRV needs to be
+  bumped. If MSRV must be updated, update `rust-version` key in Cargo.toml as well
+  as the MSRV version mentioned in the readme. 
 * Update the CHANGELOG as appropriate.
 * Edit the `Cargo.toml` to set the new jolly version. Run
   `cargo update -p jolly` so that the `Cargo.lock` is updated. Commit the


### PR DESCRIPTION
Jolly will track latest stable like its major `iced` dependency.

This is now mentioned in the README as well as `Cargo.toml`.

CI has also been updated to run tests on MSRV instead of whatever version of rust github happens to have installed on its runners.

Fixes #6