### PR TITLE
Modified Jolly to start with hidden window.

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -116,6 +116,9 @@ impl Application for Jolly {
         (
             jolly,
             Command::batch([
+                Command::single(command::Action::Window(window::Action::SetMode(
+                    window::Mode::Windowed,
+                ))),
                 text_input::focus(TEXT_INPUT_ID.clone()),
                 Command::perform(blocking::unblock(get_store), Message::StoreLoaded),
             ]),
@@ -239,6 +242,7 @@ pub fn main() -> Result<(), error::Error> {
     let mut settings = Settings::default();
     settings.window.size = (UI_WIDTH, UI_STARTING_HEIGHT);
     settings.window.decorations = false;
+    settings.window.visible = false;
     settings.default_text_size = UI_DEFAULT_TEXT_SIZE;
     Jolly::run(settings).map_err(error::Error::IcedError)
 }


### PR DESCRIPTION
On Windows computers, especially where animations have been disabled, starting Jolly can cause a default-sized window to appear that quickly changes shape to the regular Jolly window. 

You can also sometimes see a blank Jolly window appear first that then renders in the starting text. 

This is due to the underlying behavior of the `winit` crate that Jolly uses via `iced`. 
According to [winit issue 1536](https://github.com/rust-windowing/winit/pull/1536), certain winit platforms will display garbage data until the first rendering, so best practice is to spawn a hidden window, and only make it visible once the initial layout is ready. 

This allows winit to send the startup resize commands while the window is hidden and only show the Jolly window once we are ready to show the first frame.