### PR TITLE
Steal focus at startup

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -123,6 +123,8 @@ impl Application for Jolly {
                     window::Mode::Windowed,
                 ))),
                 text_input::focus(TEXT_INPUT_ID.clone()),
+                // steal focus after startup: fixed bug on windows where it is possible to start jolly without focus
+                Command::single(command::Action::Window(window::Action::GainFocus)),
             ]),
         )
     }


### PR DESCRIPTION
On windows, if the user types quickly enough when launching Jolly, the will steal focus back to whatever application was originally highlighted.

This means that the Jolly window will appear, but it will not be focused, and can only be closed by clicking on the window, at which point the normal Jolly exit criteria allow it to exit.