### PR TITLE
Improve display of errors in Jolly

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -149,7 +149,7 @@ impl StoreEntry {
             (None, None, None) => name.to_string(),
             _ => {
                 return Err(Error::CustomError(format!(
-                    "Error with {}: Only allow one of location/url/system",
+                    "Error with entry ['{}']: The entry should only specify one of location/url/system keys",
                     &name
                 )))
             }

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,19 +19,23 @@ pub enum Error {
 
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // Final message is used when we want to say something, but it
-        // isn't an error, so we don't say error
-        if !matches!(self, Error::FinalMessage(_)) {
-            write!(f, "Error: ")?;
-        }
-
         match self {
-            Error::StoreError(e) => e.fmt(f),
+            Error::StoreError(e) => {
+                write!(f, "while parsing jolly.toml: \n")?;
+                e.fmt(f)
+            }
             Error::IcedError(e) => e.fmt(f),
-            Error::IoError(e) => e.fmt(f),
-            Error::ParseError(e) => e.fmt(f),
+            Error::IoError(e) => {
+                write!(f, "could not access jolly.toml: \n")?;
+                e.fmt(f)
+            }
+            Error::ParseError(e) => {
+                write!(f, "while parsing jolly.toml: \n")?;
+                e.fmt(f)
+            }
             Error::PlatformError(e) => e.fmt(f),
             Error::CustomError(s) => f.write_str(s),
+            // not really an error, used to represent final message in UI
             Error::FinalMessage(s) => f.write_str(s),
         }
     }

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -286,6 +286,7 @@ pub enum ContainerStyle {
     #[default]
     Transparent,
     Selected,
+    Error,
 }
 
 impl container::StyleSheet for Theme {
@@ -304,6 +305,17 @@ impl container::StyleSheet for Theme {
                     border_radius: 5.0.into(),
                     border_width: 1.0,
                     border_color: iced_native::Color::TRANSPARENT,
+                }
+            }
+
+            ContainerStyle::Error => {
+                let bg_color: iced::Color = self.background_color.clone().into();
+                container::Appearance {
+                    text_color: Some(self.text_color.clone().into()),
+                    background: Some(bg_color.into()),
+                    border_radius: 5.0,
+                    border_width: 2.0,
+                    border_color: ui::Color::from_str("#D64541").into(),
                 }
             }
         }


### PR DESCRIPTION
Error messages are not longer cut off if they are longer than one line.