### PR TITLE
Release GH Action now included example jolly.toml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -56,7 +56,8 @@ jobs:
 
         cp {README.md,LICENSE-APACHE,LICENSE-MIT,CHANGELOG.md} "$staging/"
         cp -r docs "$staging"
-
+        cp docs/jolly.toml "$staging/"
+        
         if [ "${{ matrix.os }}" = "windows-latest" ]; then
           cp "target/release/jolly.exe" "$staging/"
           7z a "$staging.zip" "$staging"


### PR DESCRIPTION
This means that official builds of the Jolly crate will be distributed with an example file right next to the executable. Before, if a user tried to just launch Jolly from the release tarball, they would get an error from the missing example file and have to copy it over. Now the example file will already be in the right place.