### PR TITLE
Added basic CLI args to Jolly

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -101,6 +101,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc7eb209b1518d6bb87b283c20095f5228ecda460da70b44f0802523dea6da04"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -398,6 +404,21 @@ name = "cfg_aliases"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
+name = "chrono"
+version = "0.4.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
+dependencies = [
+ "android-tzdata",
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "time",
+ "wasm-bindgen",
+ "winapi",
+]
 
 [[package]]
 name = "clipboard-win"
@@ -1186,7 +1207,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
@@ -1388,6 +1409,29 @@ name = "humantime"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.57"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fad5b825842d2b38bd206f3e81d6957625fd7f0a361e345c30e01a0ae2dd613"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "wasm-bindgen",
+ "windows 0.48.0",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "iced"
@@ -1670,6 +1714,7 @@ dependencies = [
 name = "jolly"
 version = "0.2.0"
 dependencies = [
+ "chrono",
  "core-foundation",
  "core-graphics",
  "csscolorparser",
@@ -1962,7 +2007,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
 
@@ -3248,6 +3293,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "time"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
+dependencies = [
+ "libc",
+ "wasi 0.10.0+wasi-snapshot-preview1",
+ "winapi",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3640,6 +3696,12 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
+
+[[package]]
+name = "wasi"
+version = "0.10.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -413,10 +413,7 @@ checksum = "ec837a71355b28f6556dbd569b37b3f363091c0bd4b2e735674521b4c5fd9bc5"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "time",
- "wasm-bindgen",
  "winapi",
 ]
 
@@ -1207,7 +1204,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -2007,7 +2004,7 @@ checksum = "927a765cd3fc26206e66b296465fa9d3e5ab003e651c1b3c060e7956d96b19d2"
 dependencies = [
  "libc",
  "log",
- "wasi 0.11.0+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.48.0",
 ]
 
@@ -3293,17 +3290,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.1.45"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
-dependencies = [
- "libc",
- "wasi 0.10.0+wasi-snapshot-preview1",
- "winapi",
-]
-
-[[package]]
 name = "tiny-skia"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3696,12 +3682,6 @@ name = "waker-fn"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d5b2c62b4012a3e1eca5a7e077d13b3bf498c4073e33ccd58626607748ceeca"
-
-[[package]]
-name = "wasi"
-version = "0.10.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,8 +48,7 @@ dirs = "5"
 tempfile = "3"
 
 [build-dependencies]
-chrono = "0.4.26"
-
+chrono = { version = "0.4.26", default-features = false, features = ["clock"]}
 
 [target.'cfg(windows)'.build-dependencies]
 resvg = "0.29.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,6 +47,9 @@ dirs = "5"
 [dev-dependencies] 
 tempfile = "3"
 
+[build-dependencies]
+chrono = "0.4.26"
+
 
 [target.'cfg(windows)'.build-dependencies]
 resvg = "0.29.0"

--- a/README.md
+++ b/README.md
@@ -10,10 +10,25 @@ https://user-images.githubusercontent.com/1356587/209451235-6911e5f1-fb4d-4348-9
 
 # Quick Introduction
 
-To use Jolly, simply run the `jolly` executable. Jolly will then look for a
-suitable [configuration file](docs/file-format.md#locations) `jolly.toml`. 
+To use Jolly, simply run the `jolly` executable. 
 
-By default, Jolly won't show any results: just tell you how many entries it has loaded:
+```bash
+# Run Jolly with jolly.toml in the current directory
+jolly
+```
+
+To use a config file that is not in the current directory, pass its path on the command line:
+
+```bash
+# Run Jolly with a custom config file
+jolly /path/to/custom/jolly.toml
+```
+
+For more details on how Jolly finds its config file, see the
+[documentation](docs/file-format.md#locations).
+
+By default, Jolly won't show any results: just tell you how many
+entries it has loaded:
 
 ![startup page](docs/static/startup.png)
 
@@ -29,7 +44,7 @@ or click it with the mouse.
 To learn more about the file format used by Jolly, see the [file-format](docs/file-format.md) page.
 
 To learn more about changing settings for Jolly, including how to
-customize the theme, see the [config](config.md) page.
+customize the theme, see the [config](docs/config.md) page.
 
 To learn more advanced tips and tricks, see the [advanced](docs/advanced.md) usage page.
 

--- a/build.rs
+++ b/build.rs
@@ -1,14 +1,24 @@
 // build script to add icon to Jolly executable.
 // this script is only used on windows platforms
 
+fn common() {
+    use chrono::Utc;
+    let date = Utc::now().date_naive();
+    println!("cargo:rustc-env=JOLLY_BUILD_DATE={date}");
+}
+
 // no build requirements for macos FOR NOW
 #[cfg(target_os = "macos")]
-fn main() {}
+fn main() {
+    common();
+}
 
 // check to make sure dependencies are installed
 #[cfg(all(unix, not(target_os = "macos")))]
 fn main() {
     use std::env;
+
+    common();
 
     let theme = env::var("JOLLY_DEFAULT_THEME").unwrap_or("gnome".into());
     println!("cargo:rustc-env=JOLLY_DEFAULT_THEME={}", theme);
@@ -56,6 +66,8 @@ fn main() {
 // set a nice icon
 #[cfg(windows)]
 fn main() {
+    common();
+
     // determine path to save icon to
     let out_file = format!("{}/jolly.ico", std::env::var("OUT_DIR").unwrap());
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,5 +1,19 @@
-To use Jolly, simply run the `jolly` executable. Jolly will look for a
-suitable [configuration file](file-format.md#locations) `jolly.toml`. 
+To use Jolly, simply run the `jolly` executable. 
+
+```bash
+# Run Jolly with jolly.toml in the current directory
+jolly
+```
+
+To use a config file that is not in the current directory, pass its path on the command line:
+
+```bash
+# Run Jolly with a custom config file
+jolly /path/to/custom/jolly.toml
+```
+
+For more details on how Jolly finds its config file, see the
+[documentation](file-format.md#locations).
 
 By default, Jolly won't show any results: just tell you how many entries it has loaded:
 

--- a/docs/file-format.md
+++ b/docs/file-format.md
@@ -8,6 +8,26 @@ the [TOML](https://toml.io) markup language.
 You can find out more details about the syntax of TOML on the above
 webpage, but the basics are defined below. 
 
+## <a name="locations"></a> Config File Locations
+
+Jolly searches for a config file in the following locations: 
+
+1. A custom file location specified via the command line, such as `jolly /path/to/custom/jolly.toml`
+2. A file named `jolly.toml` in the current working directory
+3. A file named `jolly.toml` in the *config directory*
+
+*config directory* is defined with different paths depending on the platform: 
+
+| Platform | Value                                 | Example                                  |
+|----------|---------------------------------------|------------------------------------------|
+| Linux    | `$XDG_CONFIG_HOME` or `$HOME`/.config | /home/alice/.config                      |
+| macOS    | `$HOME`/Library/Application Support   | /Users/Alice/Library/Application Support |
+| Windows  | `{FOLDERID_LocalAppData}`             | C:\Users\Alice\AppData\Local             |
+
+If a `jolly.toml` config file cannot be located, Jolly will show an error message and exit. 
+
+## Example Config
+
 For the purposes of this example, we will refer to an example `jolly.toml` file located in this documentation (you can find a full version of the file [here](jolly.toml)):
 
 ```toml
@@ -296,17 +316,6 @@ url = 'https://duckduckgo.com/?q=%s'
 keyword = 'ddg'
 ```
 
-# <a name="locations"></a> Jolly Database Search Locations
-
-
-Jolly searches for a database file (always named `jolly.toml` in the
-following locations, in descending order of priority:
-
-1. The current working directory
-2. In the User's [configuration directory](https://docs.rs/dirs/latest/dirs/fn.config_dir.html)
-
-*Note: The user's configuration directory is platform dependent, the
-value for various platforms can be found in the above link.*
 
 # <a name="errors"></a> Errors
 Sometimes Jolly will encounter an error can cannot proceed. Usually,

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,71 @@
+// command line parsing for jolly
+use std::process::ExitCode;
+
+fn help() {
+    let description = env!("CARGO_PKG_DESCRIPTION");
+    let exe = option_env!("CARGO_BIN_NAME").unwrap_or("jolly");
+    let name = env!("CARGO_PKG_NAME");
+    println!(
+        r#"{description}
+
+Usage: {exe} [OPTIONS] [CONFIG FILE]
+
+Options:
+-V, --version	Print version info and exit
+-h, --help	Print this help and exit
+
+Use the optional parameter [CONFIG FILE] to use a non-default config file
+
+For more details, see the {name} docs: https://github.com/apgoetz/jolly/blob/main/docs/README.md
+"#
+    );
+}
+
+fn version() {
+    let version = env!("CARGO_PKG_VERSION");
+    let name = env!("CARGO_PKG_NAME");
+    let date = env!("JOLLY_BUILD_DATE");
+
+    println!("{name} {version} {date}");
+}
+
+fn err_help() {
+    let name = option_env!("CARGO_BIN_NAME").unwrap_or("jolly");
+    eprintln!("Try '{name} --help' for more information");
+}
+
+#[derive(Default)]
+pub struct ParsedArgs {
+    pub config: Option<String>,
+}
+
+pub fn parse_args<I: Iterator<Item = String>>(args: I) -> Result<ParsedArgs, ExitCode> {
+    let mut parsed_args = ParsedArgs::default();
+
+    for arg in args.skip(1) {
+        if arg == "-V" || arg == "-v" || arg == "--version" {
+            version();
+            return Err(ExitCode::SUCCESS);
+        }
+
+        if arg == "-h" || arg == "--help" {
+            help();
+            return Err(ExitCode::SUCCESS);
+        }
+
+        if arg.starts_with("-") {
+            eprintln!("Invalid option '{arg}'");
+            err_help();
+            return Err(ExitCode::FAILURE);
+        }
+
+        if parsed_args.config.is_none() {
+            parsed_args.config = Some(arg)
+        } else {
+            eprintln!("Multiple config files passed, only one config file supported at this time");
+            err_help();
+            return Err(ExitCode::FAILURE);
+        }
+    }
+    Ok(parsed_args)
+}

--- a/src/config.rs
+++ b/src/config.rs
@@ -58,6 +58,17 @@ impl Default for Config {
 }
 
 impl Config {
+    pub fn custom_load(path: String) -> Self {
+        let config = load_path(path);
+        match config {
+            Err(e) => Self {
+                settings: Default::default(),
+                store: Err(e),
+            },
+            Ok(c) => c,
+        }
+    }
+
     pub fn load() -> Self {
         match get_logfile().map(load_path) {
             Ok(config) => config.unwrap_or_else(|e| Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,6 +15,7 @@ use iced::{executor, Application, Command, Element, Length, Renderer, Size};
 use lazy_static;
 use std::sync::mpsc;
 
+pub mod cli;
 pub mod config;
 mod custom;
 mod entry;


### PR DESCRIPTION
You can now specify a custom path to your config file, as well see --help and --version via command line.