### PR TITLE
Cleaned up errors in Jolly

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -24,12 +24,12 @@ impl LogSettings {
             .format_timestamp_micros()
             .target(env_logger::fmt::Target::Stderr);
 
-        if let Some(f) = &self.file {
+        if let Some(fname) = &self.file {
             let f = std::fs::OpenOptions::new()
                 .append(true)
                 .create(true)
-                .open(f)
-                .map_err(error::Error::IoError)?;
+                .open(fname)
+                .map_err(|e| error::Error::IoError(self.file.clone(), e))?;
             builder.target(env_logger::fmt::Target::Pipe(Box::new(f)));
         }
 

--- a/src/store.rs
+++ b/src/store.rs
@@ -150,7 +150,7 @@ pub mod tests {
         let toml = r#"bare_key = 42"#;
         let text = parse_store(toml);
         assert!(
-            matches!(text, Err(entry::Error::BareKeyError(_))),
+            matches!(text, Err(entry::Error::ParseError(_))),
             "{:?}",
             text
         )


### PR DESCRIPTION
Errors now properly show the correct filename.

Toml Errors no longer show the gutter display that required a fixed point font.