### PR TITLE
Fix panics when selecting empty results

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -231,12 +231,22 @@ impl Application for Jolly {
                     } else if key == keyboard::KeyCode::NumpadEnter
                         || key == keyboard::KeyCode::Enter
                     {
-                        return self.handle_selection(self.search_results.selected());
+                        let cmd = if let Some(id) = self.search_results.selected() {
+                            self.handle_selection(id)
+                        } else {
+                            iced::window::close()
+                        };
+                        return cmd;
                     }
                 }
 
                 if keyboard::Event::CharacterReceived('\r') == e {
-                    return self.handle_selection(self.search_results.selected());
+                    let cmd = if let Some(id) = self.search_results.selected() {
+                        self.handle_selection(id)
+                    } else {
+                        iced::window::close()
+                    };
+                    return cmd;
                 }
 
                 if let keyboard::Event::ModifiersChanged(m) = e {

--- a/src/search_results.rs
+++ b/src/search_results.rs
@@ -53,8 +53,8 @@ impl SearchResults {
         }
     }
 
-    pub fn selected(&self) -> entry::EntryId {
-        self.entries[self.selected]
+    pub fn selected(&self) -> Option<entry::EntryId> {
+        self.entries.get(self.selected).map(|e| *e)
     }
 
     pub fn handle_kb(&mut self, event: keyboard::Event) {


### PR DESCRIPTION
Fix error where empty search results would still be indexed. Jolly now exits if a selection is made with an empty search result.