### PR TITLE
Added heuristics to system icons

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1736,6 +1736,7 @@ dependencies = [
  "url",
  "urlencoding",
  "usvg 0.29.0",
+ "which",
  "windows 0.48.0",
  "winres",
  "xdg-mime",
@@ -4007,6 +4008,17 @@ dependencies = [
  "bitflags 2.3.3",
  "js-sys",
  "web-sys",
+]
+
+[[package]]
+name = "which"
+version = "4.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2441c784c52b289a054b7201fc93253e288f094e2f4be9058343127c4226a269"
+dependencies = [
+ "either",
+ "libc",
+ "once_cell",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ once_cell = "1.18.0"
 resvg = "0.34.0"
 env_logger = "0.10.0"
 log = "0.4.19"
+which = "4.4.0"
 
 [target.'cfg(target_os = "macos")'.dependencies]
 objc = "0.2"

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -165,7 +165,7 @@ impl StoreEntry {
             icon::IconType::custom(p)
         } else {
             match &entry {
-                EntryType::SystemEntry(loc) => icon::IconType::file(loc),
+                EntryType::SystemEntry(loc) => icon::IconType::system(loc),
                 EntryType::FileEntry(loc) => {
                     let parsed_loc = format_param(loc, "");
 
@@ -683,7 +683,7 @@ mod tests {
                 .map(str::to_string)
                 .collect(),
             icon: None,
-            icon_type: IconType::file("foo bar"),
+            icon_type: IconType::system("foo bar"),
         };
 
         let entry = parse_entry(&toml);


### PR DESCRIPTION
system entries are usually shell commands, which don't correspond to a single file on disk. This commit adds heuristics for identifying the icons for these system entries, so that the first (space deliminated) word is checked to see if it has a standalone icon.