### PR TITLE
Fixed flaky windows tests for icons

### DIFF
--- a/src/icon/mod.rs
+++ b/src/icon/mod.rs
@@ -548,27 +548,18 @@ mod tests {
         #[cfg(target_os = "macos")]
         let happycase_urls = vec!["http://example.com", "https://example.com"];
 
-        #[cfg(target_os = "windows")]
-        let happycase_urls = vec!["im:foo.com"];
-
         #[cfg(all(unix, not(target_os = "macos")))]
         let happycase_urls: Vec<&str> = Vec::new();
 
         #[cfg(windows)]
-        let happycase_urls: Vec<_> = happycase_urls
-            .into_iter()
-            .chain(
-                [
-                    "accountpicturefile:",
-                    "AudioCD:",
-                    "batfile:",
-                    "fonfile:",
-                    "hlpfile:",
-                    "regedit:",
-                ]
-                .into_iter(),
-            )
-            .collect();
+        let happycase_urls: Vec<_> = vec![
+            "accountpicturefile:",
+            "AudioCD:",
+            "batfile:",
+            "fonfile:",
+            "hlpfile:",
+            "regedit:",
+        ];
 
         let sadcase_urls = vec![
             "totallynonexistantprotocol:",

--- a/src/icon/mod.rs
+++ b/src/icon/mod.rs
@@ -415,6 +415,29 @@ mod tests {
 
     use super::{Icon, IconError, IconInterface, IconSettings};
 
+    trait Complain {
+        fn complain(&self) -> String;
+    }
+
+    impl<T: std::error::Error> Complain for T {
+        fn complain(&self) -> String {
+            let mut msg = self.to_string();
+            if let Some(next) = self.source() {
+                let mut next = next;
+                loop {
+                    msg.push_str(&format!(" Caused by: {}", next));
+                    if let Some(n) = next.source() {
+                        next = n;
+                    } else {
+                        return msg;
+                    }
+                }
+            } else {
+                return msg;
+            }
+        }
+    }
+
     fn hash_icon(icon: &Icon) -> u64 {
         let mut hash = DefaultHasher::new();
         match icon {
@@ -522,8 +545,11 @@ mod tests {
     fn common_urls_are_iconlike() {
         use crate::icon::Context;
         // test urls that default macos has support for
-        #[cfg(any(target_os = "macos", target_os = "windows"))]
-        let happycase_urls = vec!["https://example.com"];
+        #[cfg(target_os = "macos")]
+        let happycase_urls = vec!["http://example.com", "https://example.com"];
+
+        #[cfg(target_os = "windows")]
+        let happycase_urls = vec!["im:foo.com"];
 
         #[cfg(all(unix, not(target_os = "macos")))]
         let happycase_urls: Vec<&str> = Vec::new();
@@ -569,7 +595,7 @@ mod tests {
                 os.get_icon_for_url(&u)
                     .context(format!("failed to load '{u}'"))
                     .err()
-                    .map(|e| e.to_string())
+                    .map(|e| e.complain())
             })
             .chain(sadcase_urls.into_iter().filter_map(|u| {
                 os.get_icon_for_url(&u)


### PR DESCRIPTION
For some reason, when running icon tests on windows, the default protocol handler for http and https protocols can fail to load its icons. This default handler is of course, ms Edge, and I have no idea why it is flaky.

So as a workaround, the testcase for icon loading on windows now uses protocol "im", which of course launches MS Teams...